### PR TITLE
bugfix ViaNode on index

### DIFF
--- a/handlers.reflector.go
+++ b/handlers.reflector.go
@@ -36,7 +36,7 @@ func showStationDataJSON(c *gin.Context) {
   type stationData struct {
     Callsign string `json:"callsign"`
     CallsignSuffix string `json:"callsignsuffix"`
-    LinkPeer string `json:"linkpeer"` 
+    ViaNode string `json:"vianode"`
     OnModule string `json:"onmodule"`
     LastHeard string `json:"lastheard"`
   }
@@ -51,7 +51,7 @@ func showStationDataJSON(c *gin.Context) {
     data.Stations = append(data.Stations, stationData{
       Callsign: callsignSplit[0],
       CallsignSuffix: callsignSplit[1],
-      LinkPeer: station.ViaPeer,
+      ViaNode: station.ViaNode,
       OnModule: station.OnModule,
       LastHeard: station.LastHeardTime,
     })

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
                   <th scope="row"></th>
                   <td><a :href="`https://www.qrz.com/db/${ station.callsign }`" target="_blank">${ station.callsign }</td>
                   <td>${ station.callsignsuffix }</td>
-                  <td>${ station.linkpeer }</td>
+                  <td>${ station.vianode }</td>
                   <td>${ station.onmodule }</td>
                   <td>${ station.lastheard }</td>
                 </tr>


### PR DESCRIPTION
the Link/Peer column in the last heard page was showing the reflector callsign instead of the node the station is connecting through. Simple bugfix.