### PR TITLE
Patch callsign split function

### DIFF
--- a/handlers.reflector.go
+++ b/handlers.reflector.go
@@ -43,9 +43,9 @@ func (d *Dashboard) showStationDataJSON(c *gin.Context) {
 		Stations []stationData `json:"stations"`
 	}
 	for i, station := range d.Reflector.ReflectorData.Stations {
-		callsignSplit := strings.Split(station.Callsign, " ")
+		callsignSplit := strings.Fields(station.Callsign)
 		if len(callsignSplit) < 2 {
-			continue
+			callsignSplit = append(callsignSplit, " ")
 		}
 		data.Stations = append(data.Stations, stationData{
 			Callsign:       callsignSplit[0],


### PR DESCRIPTION
![Screenshot 2022-10-07 094010](https://user-images.githubusercontent.com/43918257/194567336-b814a65d-0fbb-4d53-8ced-5e605039babf.png)
Station data callsigns are padded out to 8 characters, meaning that there could be more than one space between callsign and suffix. This patch corrects the callsignSplit function to grab the callsign suffix, and pads the data with whitespace if the suffix is not present. A suffix may not be present on RF clients, for example.