### PR TITLE
Mask IP addresses in links API

### DIFF
--- a/backend/pkg/dashboard/handlers.go
+++ b/backend/pkg/dashboard/handlers.go
@@ -101,7 +101,29 @@ func (d *Dashboard) showPeers(c *gin.Context) {
 
 func (d *Dashboard) showLinksDataJSON(c *gin.Context) {
 	d.Reflector.refreshIfNeeded()
-	c.JSON(200, d.Reflector.ReflectorData.Nodes)
+
+	type linkData struct {
+		Callsign      string `json:"callsign"`
+		IPAddress     string `json:"ip"`
+		LinkedModule  string `json:"linkedmodule"`
+		Protocol      string `json:"protocol"`
+		ConnectTime   string `json:"connecttime"`
+		LastHeardTime string `json:"lastheardtime"`
+	}
+
+	links := make([]linkData, 0, len(d.Reflector.ReflectorData.Nodes))
+	for _, node := range d.Reflector.ReflectorData.Nodes {
+		links = append(links, linkData{
+			Callsign:      node.Callsign,
+			IPAddress:     maskIP(node.IPAddress),
+			LinkedModule:  node.LinkedModule,
+			Protocol:      node.Protocol,
+			ConnectTime:   node.ConnectTime,
+			LastHeardTime: node.LastHeardTime,
+		})
+	}
+
+	c.JSON(200, links)
 }
 
 func (d *Dashboard) showModulesInUseJSON(c *gin.Context) {

--- a/backend/pkg/dashboard/utilities.go
+++ b/backend/pkg/dashboard/utilities.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -56,6 +57,32 @@ func mrefdUptime(pidFile, checkFile string) (time.Duration, error) {
 		return uptime, fmt.Errorf("check file is older than two minutes")
 	}
 	return uptime, nil
+}
+
+// maskIP partially hides an IP address so only the first two
+// octets or segments are returned. For IPv4 the result will
+// look like "X.X.xx.xx" and for IPv6 "X:X:xx:xx...".
+func maskIP(ip string) string {
+	if ip == "" {
+		return ""
+	}
+	if strings.Contains(ip, ".") {
+		parts := strings.Split(ip, ".")
+		if len(parts) >= 2 {
+			return fmt.Sprintf("%s.%s.xx.xx", parts[0], parts[1])
+		}
+	}
+	if strings.Contains(ip, ":") {
+		parts := strings.Split(ip, ":")
+		if len(parts) >= 2 {
+			masked := make([]string, len(parts)-2)
+			for i := range masked {
+				masked[i] = "xx"
+			}
+			return strings.Join(append([]string{parts[0], parts[1]}, masked...), ":")
+		}
+	}
+	return ip
 }
 
 // if needed to test the function


### PR DESCRIPTION
For privacy reasons or non-ethical actors, I think these should be censored.
Thanks!